### PR TITLE
Update to varxsim line 292

### DIFF
--- a/R/rmgarch-var.R
+++ b/R/rmgarch-var.R
@@ -289,7 +289,7 @@ varxsim = function(X, Bcoef, p, n.sim, n.start, prereturns, resids, mexsimdata)
 		mxn = ncol(mexsimdata)
 	} else{
 		mxn = 0
-		Bcoef = Bcoef[,1:(m*p+1)]
+		Bcoef = Bcoef[,1:(m*p+1*constant)]
 	}
 	dmat2 = NULL
 	if( is.null(prereturns) ){


### PR DESCRIPTION
The original varxsim assumes the VAR model has a constant coefficient in Bceof, causing "subscript out of bounds" if not - propose change it to 1*constant